### PR TITLE
Hide Data.Either.fromRight

### DIFF
--- a/src/DependencyInjector.hs
+++ b/src/DependencyInjector.hs
@@ -16,7 +16,7 @@ import Language.Haskell.TH
 import Common
 import Data.List as L
 import Language.Haskell.Meta (parseExp, parseDecs)
-import Data.Either
+import Data.Either hiding (fromRight)
 import System.IO.Unsafe
 import qualified Data.Set as Set
 import qualified Data.Tree as Tree


### PR DESCRIPTION
In base 4.10.0.0, Data.Either added a function:

```haskell
fromRight :: Either a b -> b
```

Which is the same function that is defined inside hs-di. This causes an ambiguity when building with newer versions of GHC.

This commit hides `fromRight` so builds can happen with base >=4.10.0.0 while retaining compatibility with base <4.10.0.0.