### PR TITLE
Double comment inside Template Haskell

### DIFF
--- a/src/DependencyInjector.hs
+++ b/src/DependencyInjector.hs
@@ -354,7 +354,7 @@ injDecsG n (name, nameI, nameD, depsD, deps, argsSigs) = do
         $(return $ TupE $ map (mkName .> VarE) ((nameI) : map (++ "T") (filteredSigs $> map fst)))
       $(return $ VarP $ mkName $ name ++ "A") =
         -- assemble $asdasd
-        -- $(assemble $ depOP nameI (map (flip depOP []) deps))
+        -- -- $(assemble $ depOP nameI (map (flip depOP []) deps))
         $(if anyMonadicImmDeps
           then [e| monadicInjectError $(litE $ stringL nameD) |]
           else return $ convertDepsToExp $ depOP nameI (map (flip depOP []) (filteredSigs $> map fst)))


### PR DESCRIPTION
This commit double comments a line containing a syntax error as the first comment is removed during compilation, causing a parse error when attempting to use Haddock.

Fixes: https://github.com/Wizek/hs-di/issues/3